### PR TITLE
More specific .DS_Store matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 // /^npm-debug\.log$/,   // npm error log
 // /^\..*\.swp$/,        // vim state
 // // OS X
-// /^\.DS_Store/,        // stores custom folder attributes
+// /^\.DS_Store$/,       // stores custom folder attributes
 // /^\.AppleDouble$/,    // stores additional file resources
 // /^\.LSOverride$/,     // contains the absolute path to the app to be used
 // /^Icon[\r\?]?/,       // custom Finder icon
@@ -19,7 +19,7 @@
 // /^ehthumbs\.db$/,     // folder config file
 // /^Desktop\.ini$/      // stores custom folder attributes
 
-exports.re = /^npm-debug\.log$|^\..*\.swp$|^\.DS_Store|^\.AppleDouble$|^\.LSOverride$|^Icon[\r\?]?|^\._.*|^.Spotlight-V100$|\.Trashes|^__MACOSX$|~$|^Thumbs\.db$|^ehthumbs\.db$|^Desktop\.ini$/;
+exports.re = /^npm-debug\.log$|^\..*\.swp$|^\.DS_Store$|^\.AppleDouble$|^\.LSOverride$|^Icon[\r\?]?|^\._.*|^.Spotlight-V100$|\.Trashes|^__MACOSX$|~$|^Thumbs\.db$|^ehthumbs\.db$|^Desktop\.ini$/;
 
 exports.is = function (filename) {
 	return exports.re.test(filename);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "junk",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Filter out OS junk files like .DS_Store and Thumbs.db",
   "license": "MIT",
   "repository": "sindresorhus/junk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "junk",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Filter out OS junk files like .DS_Store and Thumbs.db",
   "license": "MIT",
   "repository": "sindresorhus/junk",


### PR DESCRIPTION
Tweaked so '.DS_Store' strings are matched while '.DS_Store files drive some people crazy.txt' strings are not.

Useful if people make fun mistakes like I did. Like passing an array of files to junk instead of a string. Hehe, oops.