### PR TITLE
Fix regex for ".Spotlight-V100"

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 // /^\.LSOverride$/,     // contains the absolute path to the app to be used
 // /^Icon[\r\?]?/,       // custom Finder icon
 // /^\._.*/,             // thumbnail
-// /^.Spotlight-V100$/,  // file that might appear on external disk
+// /^\.Spotlight-V100$/,  // file that might appear on external disk
 // /\.Trashes/,          // file that might appear on external disk
 // /^__MACOSX$/,         // resource fork
 // // Linux
@@ -19,7 +19,7 @@
 // /^ehthumbs\.db$/,     // folder config file
 // /^Desktop\.ini$/      // stores custom folder attributes
 
-exports.re = /^npm-debug\.log$|^\..*\.swp$|^\.DS_Store$|^\.AppleDouble$|^\.LSOverride$|^Icon[\r\?]?|^\._.*|^.Spotlight-V100$|\.Trashes|^__MACOSX$|~$|^Thumbs\.db$|^ehthumbs\.db$|^Desktop\.ini$/;
+exports.re = /^npm-debug\.log$|^\..*\.swp$|^\.DS_Store$|^\.AppleDouble$|^\.LSOverride$|^Icon[\r\?]?|^\._.*|^\.Spotlight-V100$|\.Trashes|^__MACOSX$|~$|^Thumbs\.db$|^ehthumbs\.db$|^Desktop\.ini$/;
 
 exports.is = function (filename) {
 	return exports.re.test(filename);


### PR DESCRIPTION
The regex was missing a backslash (\\) character before the dot (.)
meaning that any character would be accepted in that position, not just
a dot.