### PR TITLE
Use array of strings to build RegExp

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,29 +1,30 @@
 'use strict';
 
-// # All
-// /^npm-debug\.log$/,           // npm error log
-// /^\..*\.swp$/,                // Vim state
+const blacklist = [
+	// # All
+	'^npm-debug\\.log$',             // Error log for npm
+	'^\\..*\\.swp$',                 // Swap file for vim state
+	// # macOS
+	'^\\.DS_Store$',                 // Stores custom folder attributes
+	'^\\.AppleDouble$',              // Stores additional file resources
+	'^\\.LSOverride$',               // Contains the absolute path to the app to be used
+	'^Icon\\r$',                     // Custom Finder icon: http://superuser.com/questions/298785/icon-file-on-os-x-desktop
+	'^\\._.*',                       // Thumbnail
+	'^\\.Spotlight-V100(?:$|\\/)',   // Directory that might appear on external disk
+	'\\.Trashes',                    // File that might appear on external disk
+	'^__MACOSX$',                    // Resource fork
+	// # Linux
+	'~$',                            // Backup file
+	// # Windows
+	'^Thumbs\\.db$',                 // Image file cache
+	'^ehthumbs\\.db$',               // Folder config file
+	'^Desktop\\.ini$',               // Stores custom folder attributes
+	'@eaDir$'                        // Synology Diskstation "hidden" folder where the server stores thumbnails
+];
 
-// # macOS
-// /^\.DS_Store$/,               // Stores custom folder attributes
-// /^\.AppleDouble$/,            // Stores additional file resources
-// /^\.LSOverride$/,             // Contains the absolute path to the app to be used
-// /^Icon\r$/,                   // Custom Finder icon: http://superuser.com/questions/298785/icon-file-on-os-x-desktop
-// /^\._.*/,                     // Thumbnail
-// /^\.Spotlight-V100(?:$|\/)/,  // Directory that might appear on external disk
-// /\.Trashes/,                  // File that might appear on external disk
-// /^__MACOSX$/,                 // Resource fork
+exports.re = new RegExp(blacklist.join('|'));
 
-// # Linux
-// /~$/,                         // Backup file
-
-// # Windows
-// /^Thumbs\.db$/,               // Image file cache
-// /^ehthumbs\.db$/,             // Folder config file
-// /^Desktop\.ini$/              // Stores custom folder attributes
-// /^@eaDir$/                    // Synology Diskstation "hidden" folder where the server stores thumbnails
-
-exports.regex = exports.re = /^npm-debug\.log$|^\..*\.swp$|^\.DS_Store$|^\.AppleDouble$|^\.LSOverride$|^Icon\r$|^\._.*|^\.Spotlight-V100(?:$|\/)|\.Trashes|^__MACOSX$|~$|^Thumbs\.db$|^ehthumbs\.db$|^Desktop\.ini$|^@eaDir$/;
+exports.regex = exports.re;
 
 exports.is = filename => exports.re.test(filename);
 


### PR DESCRIPTION
Took no time at all to put together (basically just did some emacs-foo), so I'm totally fine with this PR getting rejected as not substantially better than what is currently here. My motivation behind this is to make it easier to contribute to the list, and possibly removing the redundancy in the comments. I know this has evolved from a list of `RegExp`s to this combined `RegExp`, but it seems like this is the best of both of those worlds.

Since `xo` was failing for the chained assignment, I unchained them, and since these strings *need* the escaping (or rather the `RegExp` needs them), I turned the `no-useless-escape` rule off.